### PR TITLE
LanguageElement override ToString()

### DIFF
--- a/Sync/Tools/I18n.cs
+++ b/Sync/Tools/I18n.cs
@@ -106,6 +106,11 @@ namespace Sync.Tools
         {
             return element.value;
         }
+
+        public override string ToString()
+        {
+            return value;
+        }
     }
     /// <summary>
     /// I18n Manager


### PR DESCRIPTION
* 给LanguageElement重载ToString()可以方便支持C#6字符串插值特性